### PR TITLE
[IMPROVEMENT] Use xcode PROJECT_DIR variable rather than a relative path

### DIFF
--- a/USBInjectAll.xcodeproj/project.pbxproj
+++ b/USBInjectAll.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 			buildConfigurationList = 84D9F2AC1BD60EA9003FC186 /* Build configuration list for PBXLegacyTarget "PreBuild" */;
 			buildPhases = (
 			);
-			buildToolPath = ./generate_Info_plist.sh;
+			buildToolPath = "$(PROJECT_DIR)/generate_Info_plist.sh";
 			buildWorkingDirectory = "";
 			dependencies = (
 			);


### PR DESCRIPTION
Using the env variable rather than a simple relative path for the prebuild target action allows tools like Hackintool to correctly leverage command line params for build automation in custom directories.